### PR TITLE
Fix iOS build on CI

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -80,10 +80,6 @@
 # include <zircon/syscalls.h>
 #endif  // GTEST_OS_FUCHSIA
 
-#if GTEST_OS_IOS
-#import <Foundation/Foundation.h>
-#endif  // GTEST_OS_IOS
-
 #include "gtest/gtest-spi.h"
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-internal.h"
@@ -1115,12 +1111,6 @@ class CapturedStream {
     // '/sdcard' and other variants cannot be relied on, as they are not
     // guaranteed to be mounted, or may have a delay in mounting.
     char name_template[] = "/data/local/tmp/gtest_captured_stream.XXXXXX";
-#  elif GTEST_OS_IOS
-    NSString* temp_path = [NSTemporaryDirectory()
-        stringByAppendingPathComponent:@"gtest_captured_stream.XXXXXX"];
-
-    char name_template[PATH_MAX + 1];
-    strncpy(name_template, [temp_path UTF8String], PATH_MAX);
 #  else
     char name_template[] = "/tmp/captured_stream.XXXXXX";
 #  endif


### PR DESCRIPTION
The project seems improperly configured because when building
for iOS and the GTEST_OS_IOS preprocessor constant is defined,
it tries to import an Objective-C header however it is unable
to parse it and the build fails brutally.